### PR TITLE
Tasks in PBIs

### DIFF
--- a/ScrumHubBackend/CQRS/CommonInRepositoryGetListQuery.cs
+++ b/ScrumHubBackend/CQRS/CommonInRepositoryGetListQuery.cs
@@ -1,0 +1,20 @@
+﻿using ScrumHubBackend.CommunicationModel.Common;
+
+namespace ScrumHubBackend.CQRS
+{
+    /// <summary>
+    /// Common part of all requests that are getting list and are executed inside repository
+    /// </summary>
+    public class CommonInRepositoryGetListQuery<T> : CommonInRepositoryRequest<PaginatedList<T>>
+    {
+        /// <summary>
+        /// Page number
+        /// </summary>
+        public int PageNumber { get; set; }
+
+        /// <summary>
+        /// Page size
+        /// </summary>
+        public int PageSize { get; set; }
+    }
+}

--- a/ScrumHubBackend/CQRS/CommonInRepositoryRequest.cs
+++ b/ScrumHubBackend/CQRS/CommonInRepositoryRequest.cs
@@ -3,23 +3,38 @@
 namespace ScrumHubBackend.CQRS
 {
     /// <summary>
-    /// Common part of all requests that are executed inside repository
+    /// Interface for common part of the request
     /// </summary>
-    public abstract class CommonInRepositoryRequest<T> : IRequest<T>
+    public interface ICommonInRepositoryRequest
     {
         /// <summary>
         /// Github authorization token
         /// </summary>
-        public string? AuthToken { get; set; }
+        string? AuthToken { get; set; }
 
         /// <summary>
         /// Owner of the repository
         /// </summary>
-        public string? RepositoryOwner { get; set; }
+        string? RepositoryOwner { get; set; }
 
         /// <summary>
         /// Name of the repository
         /// </summary>
+        string? RepositoryName { get; set; }
+    }
+
+    /// <summary>
+    /// Common part of all requests that are executed inside repository
+    /// </summary>
+    public abstract class CommonInRepositoryRequest<T> : IRequest<T>, ICommonInRepositoryRequest
+    {
+        /// <inheritdoc/>
+        public string? AuthToken { get; set; }
+
+        /// <inheritdoc/>
+        public string? RepositoryOwner { get; set; }
+
+        /// <inheritdoc/>
         public string? RepositoryName { get; set; }
     }
 }

--- a/ScrumHubBackend/CQRS/CommonInRepositoryRequest.cs
+++ b/ScrumHubBackend/CQRS/CommonInRepositoryRequest.cs
@@ -1,0 +1,25 @@
+﻿using MediatR;
+
+namespace ScrumHubBackend.CQRS
+{
+    /// <summary>
+    /// Common part of all requests that are executed inside repository
+    /// </summary>
+    public abstract class CommonInRepositoryRequest<T> : IRequest<T>
+    {
+        /// <summary>
+        /// Github authorization token
+        /// </summary>
+        public string? AuthToken { get; set; }
+
+        /// <summary>
+        /// Owner of the repository
+        /// </summary>
+        public string? RepositoryOwner { get; set; }
+
+        /// <summary>
+        /// Name of the repository
+        /// </summary>
+        public string? RepositoryName { get; set; }
+    }
+}

--- a/ScrumHubBackend/CQRS/PBI/AddPBICommand.cs
+++ b/ScrumHubBackend/CQRS/PBI/AddPBICommand.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.PBI
 {

--- a/ScrumHubBackend/CQRS/PBI/AddPBICommand.cs
+++ b/ScrumHubBackend/CQRS/PBI/AddPBICommand.cs
@@ -6,23 +6,8 @@ namespace ScrumHubBackend.CQRS.PBI
     /// <summary>
     /// Command adding PBI to ScrumHub
     /// </summary>
-    public class AddPBICommand : IRequest<BacklogItem>
+    public class AddPBICommand : CommonInRepositoryRequest<BacklogItem>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Name of the PBI
         /// </summary>

--- a/ScrumHubBackend/CQRS/PBI/AddPBICommandHandler.cs
+++ b/ScrumHubBackend/CQRS/PBI/AddPBICommandHandler.cs
@@ -13,15 +13,17 @@ namespace ScrumHubBackend.CQRS.PBI
         private readonly ILogger<AddPBICommandHandler> _logger;
         private readonly IGitHubClientFactory _gitHubClientFactory;
         private readonly DatabaseContext _dbContext;
+        private readonly IMediator _mediator;
 
         /// <summary>
         /// Constructor
         /// </summary>
-        public AddPBICommandHandler(ILogger<AddPBICommandHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext)
+        public AddPBICommandHandler(ILogger<AddPBICommandHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext, IMediator mediator)
         {
             _logger = logger ?? throw new ArgumentException(null, nameof(logger));
             _dbContext = dbContext ?? throw new ArgumentException(null, nameof(dbContext));
             _gitHubClientFactory = clientFactory ?? throw new ArgumentException(null, nameof(clientFactory));
+            _mediator = mediator ?? throw new ArgumentException(null, nameof(mediator));
         }
 
         /// <inheritdoc/>
@@ -49,7 +51,7 @@ namespace ScrumHubBackend.CQRS.PBI
 
             newPBI.UpdateAcceptanceCriteria(request.AcceptanceCriteria ?? new List<string>(), _dbContext);
 
-            return Task.FromResult(new BacklogItem(newPBI.Id, _dbContext));
+            return Task.FromResult(new BacklogItem(newPBI.Id, request, _dbContext, _mediator));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/PBI/EstimatePBICommand.cs
+++ b/ScrumHubBackend/CQRS/PBI/EstimatePBICommand.cs
@@ -6,23 +6,8 @@ namespace ScrumHubBackend.CQRS.PBI
     /// <summary>
     /// Command for finishing one PBI
     /// </summary>
-    public class EstimatePBICommand : IRequest<BacklogItem>
+    public class EstimatePBICommand : CommonInRepositoryRequest<BacklogItem>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Id of the PBI
         /// </summary>

--- a/ScrumHubBackend/CQRS/PBI/EstimatePBICommand.cs
+++ b/ScrumHubBackend/CQRS/PBI/EstimatePBICommand.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.PBI
 {

--- a/ScrumHubBackend/CQRS/PBI/EstimatePBICommandHandler.cs
+++ b/ScrumHubBackend/CQRS/PBI/EstimatePBICommandHandler.cs
@@ -13,15 +13,17 @@ namespace ScrumHubBackend.CQRS.PBI
         private readonly ILogger<EstimatePBICommandHandler> _logger;
         private readonly IGitHubClientFactory _gitHubClientFactory;
         private readonly DatabaseContext _dbContext;
+        private readonly IMediator _mediator;
 
         /// <summary>
         /// Constructor
         /// </summary>
-        public EstimatePBICommandHandler(ILogger<EstimatePBICommandHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext)
+        public EstimatePBICommandHandler(ILogger<EstimatePBICommandHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext, IMediator mediator)
         {
             _logger = logger ?? throw new ArgumentException(null, nameof(logger));
             _dbContext = dbContext ?? throw new ArgumentException(null, nameof(dbContext));
             _gitHubClientFactory = clientFactory ?? throw new ArgumentException(null, nameof(clientFactory));
+            _mediator = mediator ?? throw new ArgumentException(null, nameof(mediator));
         }
 
         /// <inheritdoc/>
@@ -52,7 +54,7 @@ namespace ScrumHubBackend.CQRS.PBI
             _dbContext.Update(pbi);
             _dbContext.SaveChanges();
 
-            return Task.FromResult(new BacklogItem(pbi.Id, _dbContext));
+            return Task.FromResult(new BacklogItem(pbi.Id, request, _dbContext, _mediator));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/PBI/FinishPBICommand.cs
+++ b/ScrumHubBackend/CQRS/PBI/FinishPBICommand.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.PBI
 {

--- a/ScrumHubBackend/CQRS/PBI/FinishPBICommand.cs
+++ b/ScrumHubBackend/CQRS/PBI/FinishPBICommand.cs
@@ -6,23 +6,8 @@ namespace ScrumHubBackend.CQRS.PBI
     /// <summary>
     /// Command for finishing one PBI
     /// </summary>
-    public class FinishPBICommand : IRequest<BacklogItem>
-    {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
+    public class FinishPBICommand : CommonInRepositoryRequest<BacklogItem>
+    { 
         /// <summary>
         /// Id of the PBI
         /// </summary>

--- a/ScrumHubBackend/CQRS/PBI/FinishPBICommandHandler.cs
+++ b/ScrumHubBackend/CQRS/PBI/FinishPBICommandHandler.cs
@@ -13,15 +13,17 @@ namespace ScrumHubBackend.CQRS.PBI
         private readonly ILogger<FinishPBICommandHandler> _logger;
         private readonly IGitHubClientFactory _gitHubClientFactory;
         private readonly DatabaseContext _dbContext;
+        private readonly IMediator _mediator;
 
         /// <summary>
         /// Constructor
         /// </summary>
-        public FinishPBICommandHandler(ILogger<FinishPBICommandHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext)
+        public FinishPBICommandHandler(ILogger<FinishPBICommandHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext, IMediator mediator)
         {
             _logger = logger ?? throw new ArgumentException(null, nameof(logger));
             _dbContext = dbContext ?? throw new ArgumentException(null, nameof(dbContext));
             _gitHubClientFactory = clientFactory ?? throw new ArgumentException(null, nameof(clientFactory));
+            _mediator = mediator ?? throw new ArgumentException(null, nameof(mediator));
         }
 
         /// <inheritdoc/>
@@ -52,7 +54,7 @@ namespace ScrumHubBackend.CQRS.PBI
             _dbContext.Update(pbi);
             _dbContext.SaveChanges();
 
-            return Task.FromResult(new BacklogItem(pbi.Id, _dbContext));
+            return Task.FromResult(new BacklogItem(pbi.Id, request, _dbContext, _mediator));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/PBI/GetOnePBIQuery.cs
+++ b/ScrumHubBackend/CQRS/PBI/GetOnePBIQuery.cs
@@ -6,23 +6,8 @@ namespace ScrumHubBackend.CQRS.PBI
     /// <summary>
     /// Gets one PBI
     /// </summary>
-    public class GetOnePBIQuery : IRequest<BacklogItem>
+    public class GetOnePBIQuery : CommonInRepositoryRequest<BacklogItem>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Id of the PBI
         /// </summary>

--- a/ScrumHubBackend/CQRS/PBI/GetOnePBIQuery.cs
+++ b/ScrumHubBackend/CQRS/PBI/GetOnePBIQuery.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.PBI
 {

--- a/ScrumHubBackend/CQRS/PBI/GetOnePBIQueryHandler.cs
+++ b/ScrumHubBackend/CQRS/PBI/GetOnePBIQueryHandler.cs
@@ -13,15 +13,17 @@ namespace ScrumHubBackend.CQRS.PBI
         private readonly ILogger<GetOnePBIQueryHandler> _logger;
         private readonly IGitHubClientFactory _gitHubClientFactory;
         private readonly DatabaseContext _dbContext;
+        private readonly IMediator _mediator;
 
         /// <summary>
         /// Constructor
         /// </summary>
-        public GetOnePBIQueryHandler(ILogger<GetOnePBIQueryHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext)
+        public GetOnePBIQueryHandler(ILogger<GetOnePBIQueryHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext, IMediator mediator)
         {
             _logger = logger ?? throw new ArgumentException(null, nameof(logger));
             _dbContext = dbContext ?? throw new ArgumentException(null, nameof(dbContext));
             _gitHubClientFactory = clientFactory ?? throw new ArgumentException(null, nameof(clientFactory));
+            _mediator = mediator ?? throw new ArgumentException(null, nameof(mediator));
         }
 
         /// <inheritdoc/>
@@ -45,7 +47,7 @@ namespace ScrumHubBackend.CQRS.PBI
             if (pbi == null || pbi?.RepositoryId != dbRepository.Id)
                 throw new NotFoundException("Backlog item not found in ScrumHub");
 
-            return Task.FromResult(new BacklogItem(pbi.Id, _dbContext));
+            return Task.FromResult(new BacklogItem(pbi.Id, request, _dbContext, _mediator));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/PBI/GetPBIsQuery.cs
+++ b/ScrumHubBackend/CQRS/PBI/GetPBIsQuery.cs
@@ -7,23 +7,8 @@ namespace ScrumHubBackend.CQRS.PBI
     /// <summary>
     /// Query for getting all PBIs from repository
     /// </summary>
-    public class GetPBIsQuery : IRequest<PaginatedList<BacklogItem>>
+    public class GetPBIsQuery : CommonInRepositoryRequest<PaginatedList<BacklogItem>>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Page number
         /// </summary>

--- a/ScrumHubBackend/CQRS/PBI/GetPBIsQuery.cs
+++ b/ScrumHubBackend/CQRS/PBI/GetPBIsQuery.cs
@@ -1,24 +1,12 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
-using ScrumHubBackend.CommunicationModel.Common;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.PBI
 {
     /// <summary>
     /// Query for getting all PBIs from repository
     /// </summary>
-    public class GetPBIsQuery : CommonInRepositoryRequest<PaginatedList<BacklogItem>>
+    public class GetPBIsQuery : CommonInRepositoryGetListQuery<BacklogItem>
     {
-        /// <summary>
-        /// Page number
-        /// </summary>
-        public int PageNumber { get; set; }
-
-        /// <summary>
-        /// Page size
-        /// </summary>
-        public int PageSize { get; set; }
-
         /// <summary>
         /// Filter for name of type "Contains"
         /// </summary>

--- a/ScrumHubBackend/CQRS/PBI/RemovePBICommand.cs
+++ b/ScrumHubBackend/CQRS/PBI/RemovePBICommand.cs
@@ -5,23 +5,8 @@ namespace ScrumHubBackend.CQRS.PBI
     /// <summary>
     /// Command for removing one PBI
     /// </summary>
-    public class RemovePBICommand : IRequest<Unit>
+    public class RemovePBICommand : CommonInRepositoryRequest<Unit>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Id of the PBI
         /// </summary>

--- a/ScrumHubBackend/CQRS/PBI/UpdatePBICommand.cs
+++ b/ScrumHubBackend/CQRS/PBI/UpdatePBICommand.cs
@@ -6,23 +6,8 @@ namespace ScrumHubBackend.CQRS.PBI
     /// <summary>
     /// Command for updating one PBI
     /// </summary>
-    public class UpdatePBICommand : IRequest<BacklogItem>
+    public class UpdatePBICommand : CommonInRepositoryRequest<BacklogItem>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Id of the PBI
         /// </summary>

--- a/ScrumHubBackend/CQRS/PBI/UpdatePBICommand.cs
+++ b/ScrumHubBackend/CQRS/PBI/UpdatePBICommand.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.PBI
 {

--- a/ScrumHubBackend/CQRS/PBI/UpdatePBICommandHandler.cs
+++ b/ScrumHubBackend/CQRS/PBI/UpdatePBICommandHandler.cs
@@ -14,15 +14,17 @@ namespace ScrumHubBackend.CQRS.PBI
         private readonly ILogger<UpdatePBICommandHandler> _logger;
         private readonly IGitHubClientFactory _gitHubClientFactory;
         private readonly DatabaseContext _dbContext;
+        private readonly IMediator _mediator;
 
         /// <summary>
         /// Constructor
         /// </summary>
-        public UpdatePBICommandHandler(ILogger<UpdatePBICommandHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext)
+        public UpdatePBICommandHandler(ILogger<UpdatePBICommandHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext, IMediator mediator)
         {
             _logger = logger ?? throw new ArgumentException(null, nameof(logger));
             _dbContext = dbContext ?? throw new ArgumentException(null, nameof(dbContext));
             _gitHubClientFactory = clientFactory ?? throw new ArgumentException(null, nameof(clientFactory));
+            _mediator = mediator ?? throw new ArgumentException(null, nameof(mediator));
         }
 
         /// <inheritdoc/>
@@ -56,7 +58,7 @@ namespace ScrumHubBackend.CQRS.PBI
 
             pbi.UpdateAcceptanceCriteria(request.AcceptanceCriteria ?? new List<string>(), _dbContext);
 
-            return Task.FromResult(new CommunicationModel.BacklogItem(pbi.Id, _dbContext));
+            return Task.FromResult(new CommunicationModel.BacklogItem(pbi.Id, request, _dbContext, _mediator));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/People/GetPeopleQuery.cs
+++ b/ScrumHubBackend/CQRS/People/GetPeopleQuery.cs
@@ -7,21 +7,7 @@ namespace ScrumHubBackend.CQRS.People
     /// <summary>
     /// Get list of all people for the repository
     /// </summary>
-    public class GetPeopleQuery : IRequest<PaginatedList<Person>>
+    public class GetPeopleQuery : CommonInRepositoryRequest<PaginatedList<Person>>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
     }
 }

--- a/ScrumHubBackend/CQRS/People/GetPeopleQuery.cs
+++ b/ScrumHubBackend/CQRS/People/GetPeopleQuery.cs
@@ -1,13 +1,11 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
-using ScrumHubBackend.CommunicationModel.Common;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.People
 {
     /// <summary>
     /// Get list of all people for the repository
     /// </summary>
-    public class GetPeopleQuery : CommonInRepositoryRequest<PaginatedList<Person>>
+    public class GetPeopleQuery : CommonInRepositoryGetListQuery<Person>
     {
     }
 }

--- a/ScrumHubBackend/CQRS/Sprints/AddSprintCommand.cs
+++ b/ScrumHubBackend/CQRS/Sprints/AddSprintCommand.cs
@@ -6,23 +6,8 @@ namespace ScrumHubBackend.CQRS.Sprints
     /// <summary>
     /// Command adding sprint to ScrumHub
     /// </summary>
-    public class AddSprintCommand : IRequest<Sprint>
+    public class AddSprintCommand : CommonInRepositoryRequest<Sprint>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Goal of the sprint
         /// </summary>

--- a/ScrumHubBackend/CQRS/Sprints/AddSprintCommand.cs
+++ b/ScrumHubBackend/CQRS/Sprints/AddSprintCommand.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.Sprints
 {

--- a/ScrumHubBackend/CQRS/Sprints/AddSprintCommandHandler.cs
+++ b/ScrumHubBackend/CQRS/Sprints/AddSprintCommandHandler.cs
@@ -13,15 +13,17 @@ namespace ScrumHubBackend.CQRS.Sprints
         private readonly ILogger<AddSprintCommandHandler> _logger;
         private readonly IGitHubClientFactory _gitHubClientFactory;
         private readonly DatabaseContext _dbContext;
+        private readonly IMediator _mediator;
 
         /// <summary>
         /// Constructor
         /// </summary>
-        public AddSprintCommandHandler(ILogger<AddSprintCommandHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext)
+        public AddSprintCommandHandler(ILogger<AddSprintCommandHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext, IMediator mediator)
         {
             _logger = logger ?? throw new ArgumentException(null, nameof(logger));
             _dbContext = dbContext ?? throw new ArgumentException(null, nameof(dbContext));
             _gitHubClientFactory = clientFactory ?? throw new ArgumentException(null, nameof(clientFactory));
+            _mediator = mediator ?? throw new ArgumentException(null, nameof(mediator));
         }
 
         /// <inheritdoc/>
@@ -82,7 +84,7 @@ namespace ScrumHubBackend.CQRS.Sprints
 
             _dbContext.SaveChanges();
 
-            return Task.FromResult(new Sprint(dbSprint, _dbContext));
+            return Task.FromResult(new Sprint(dbSprint, request, _dbContext, _mediator));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/Sprints/GetOneSprintQuery.cs
+++ b/ScrumHubBackend/CQRS/Sprints/GetOneSprintQuery.cs
@@ -6,23 +6,8 @@ namespace ScrumHubBackend.CQRS.Sprints
     /// <summary>
     /// Query getting one Sprint
     /// </summary>
-    public class GetOneSprintQuery : IRequest<Sprint>
+    public class GetOneSprintQuery : CommonInRepositoryRequest<Sprint>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Number of the sprint
         /// </summary>

--- a/ScrumHubBackend/CQRS/Sprints/GetOneSprintQuery.cs
+++ b/ScrumHubBackend/CQRS/Sprints/GetOneSprintQuery.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.Sprints
 {

--- a/ScrumHubBackend/CQRS/Sprints/GetOneSprintQueryHandler.cs
+++ b/ScrumHubBackend/CQRS/Sprints/GetOneSprintQueryHandler.cs
@@ -13,15 +13,17 @@ namespace ScrumHubBackend.CQRS.Sprints
         private readonly ILogger<GetOneSprintQueryHandler> _logger;
         private readonly IGitHubClientFactory _gitHubClientFactory;
         private readonly DatabaseContext _dbContext;
+        private readonly IMediator _mediator;
 
         /// <summary>
         /// Constructor
         /// </summary>
-        public GetOneSprintQueryHandler(ILogger<GetOneSprintQueryHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext)
+        public GetOneSprintQueryHandler(ILogger<GetOneSprintQueryHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext, IMediator mediator)
         {
             _logger = logger ?? throw new ArgumentException(null, nameof(logger));
             _dbContext = dbContext ?? throw new ArgumentException(null, nameof(dbContext));
             _gitHubClientFactory = clientFactory ?? throw new ArgumentException(null, nameof(clientFactory));
+            _mediator = mediator ?? throw new ArgumentException(null, nameof(mediator));
         }
 
         /// <inheritdoc/>
@@ -46,7 +48,7 @@ namespace ScrumHubBackend.CQRS.Sprints
             if(dbSprint == null)
                 throw new NotFoundException("Sprint not fount in the repository");
 
-            return Task.FromResult(new Sprint(dbSprint, _dbContext));
+            return Task.FromResult(new Sprint(dbSprint, request, _dbContext, _mediator));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/Sprints/GetSprintsQuery.cs
+++ b/ScrumHubBackend/CQRS/Sprints/GetSprintsQuery.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
+﻿using ScrumHubBackend.CommunicationModel;
 using ScrumHubBackend.CommunicationModel.Common;
 
 namespace ScrumHubBackend.CQRS.Sprints
@@ -7,16 +6,7 @@ namespace ScrumHubBackend.CQRS.Sprints
     /// <summary>
     /// Query getting list of sprints
     /// </summary>
-    public class GetSprintsQuery : CommonInRepositoryRequest<PaginatedList<Sprint>>
+    public class GetSprintsQuery : CommonInRepositoryGetListQuery<Sprint>
     {
-        /// <summary>
-        /// Page number
-        /// </summary>
-        public int PageNumber { get; set; }
-
-        /// <summary>
-        /// Page size
-        /// </summary>
-        public int PageSize { get; set; }
     }
 }

--- a/ScrumHubBackend/CQRS/Sprints/GetSprintsQuery.cs
+++ b/ScrumHubBackend/CQRS/Sprints/GetSprintsQuery.cs
@@ -7,23 +7,8 @@ namespace ScrumHubBackend.CQRS.Sprints
     /// <summary>
     /// Query getting list of sprints
     /// </summary>
-    public class GetSprintsQuery : IRequest<PaginatedList<Sprint>>
+    public class GetSprintsQuery : CommonInRepositoryRequest<PaginatedList<Sprint>>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Page number
         /// </summary>

--- a/ScrumHubBackend/CQRS/Sprints/GetSprintsQuery.cs
+++ b/ScrumHubBackend/CQRS/Sprints/GetSprintsQuery.cs
@@ -1,5 +1,4 @@
 ﻿using ScrumHubBackend.CommunicationModel;
-using ScrumHubBackend.CommunicationModel.Common;
 
 namespace ScrumHubBackend.CQRS.Sprints
 {

--- a/ScrumHubBackend/CQRS/Sprints/UpdateSprintCommand.cs
+++ b/ScrumHubBackend/CQRS/Sprints/UpdateSprintCommand.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.Sprints
 {

--- a/ScrumHubBackend/CQRS/Sprints/UpdateSprintCommand.cs
+++ b/ScrumHubBackend/CQRS/Sprints/UpdateSprintCommand.cs
@@ -6,23 +6,8 @@ namespace ScrumHubBackend.CQRS.Sprints
     /// <summary>
     /// Command updating one sprint
     /// </summary>
-    public class UpdateSprintCommand : IRequest<Sprint>
+    public class UpdateSprintCommand : CommonInRepositoryRequest<Sprint>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Goal of the sprint
         /// </summary>

--- a/ScrumHubBackend/CQRS/Sprints/UpdateSprintCommandHandler.cs
+++ b/ScrumHubBackend/CQRS/Sprints/UpdateSprintCommandHandler.cs
@@ -13,15 +13,17 @@ namespace ScrumHubBackend.CQRS.Sprints
         private readonly ILogger<UpdateSprintCommandHandler> _logger;
         private readonly IGitHubClientFactory _gitHubClientFactory;
         private readonly DatabaseContext _dbContext;
+        private readonly IMediator _mediator;
 
         /// <summary>
         /// Constructor
         /// </summary>
-        public UpdateSprintCommandHandler(ILogger<UpdateSprintCommandHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext)
+        public UpdateSprintCommandHandler(ILogger<UpdateSprintCommandHandler> logger, IGitHubClientFactory clientFactory, DatabaseContext dbContext, IMediator mediator)
         {
             _logger = logger ?? throw new ArgumentException(null, nameof(logger));
             _dbContext = dbContext ?? throw new ArgumentException(null, nameof(dbContext));
             _gitHubClientFactory = clientFactory ?? throw new ArgumentException(null, nameof(clientFactory));
+            _mediator = mediator ?? throw new ArgumentException(null, nameof(mediator));
         }
 
         /// <inheritdoc/>
@@ -82,7 +84,7 @@ namespace ScrumHubBackend.CQRS.Sprints
             _dbContext.Update(dbSprint);
             _dbContext.SaveChanges();
 
-            return Task.FromResult(new Sprint(dbSprint, _dbContext));
+            return Task.FromResult(new Sprint(dbSprint, request, _dbContext, _mediator));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/Tasks/AddTaskCommand.cs
+++ b/ScrumHubBackend/CQRS/Tasks/AddTaskCommand.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.Tasks
 {

--- a/ScrumHubBackend/CQRS/Tasks/AddTaskCommand.cs
+++ b/ScrumHubBackend/CQRS/Tasks/AddTaskCommand.cs
@@ -6,23 +6,8 @@ namespace ScrumHubBackend.CQRS.Tasks
     /// <summary>
     /// Command for adding new task
     /// </summary>
-    public class AddTaskCommand : IRequest<SHTask>
+    public class AddTaskCommand : CommonInRepositoryRequest<SHTask>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Name of new task
         /// </summary>

--- a/ScrumHubBackend/CQRS/Tasks/AssignTaskToPBICommand.cs
+++ b/ScrumHubBackend/CQRS/Tasks/AssignTaskToPBICommand.cs
@@ -6,23 +6,8 @@ namespace ScrumHubBackend.CQRS.Tasks
     /// <summary>
     /// Command for asssigning the task to the PBI
     /// </summary>
-    public class AssignTaskToPBICommand : IRequest<SHTask>
+    public class AssignTaskToPBICommand : CommonInRepositoryRequest<SHTask>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Id of the task
         /// </summary>

--- a/ScrumHubBackend/CQRS/Tasks/AssignTaskToPBICommand.cs
+++ b/ScrumHubBackend/CQRS/Tasks/AssignTaskToPBICommand.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.Tasks
 {

--- a/ScrumHubBackend/CQRS/Tasks/ChangePersonInTaskCommand.cs
+++ b/ScrumHubBackend/CQRS/Tasks/ChangePersonInTaskCommand.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.Tasks
 {

--- a/ScrumHubBackend/CQRS/Tasks/ChangePersonInTaskCommand.cs
+++ b/ScrumHubBackend/CQRS/Tasks/ChangePersonInTaskCommand.cs
@@ -6,23 +6,8 @@ namespace ScrumHubBackend.CQRS.Tasks
     /// <summary>
     /// Command for assigning and unassigning person from task
     /// </summary>
-    public class ChangePersonInTaskCommand : IRequest<SHTask>
+    public class ChangePersonInTaskCommand : CommonInRepositoryRequest<SHTask>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Id of the task
         /// </summary>

--- a/ScrumHubBackend/CQRS/Tasks/GetOneTaskQuery.cs
+++ b/ScrumHubBackend/CQRS/Tasks/GetOneTaskQuery.cs
@@ -6,23 +6,8 @@ namespace ScrumHubBackend.CQRS.Tasks
     /// <summary>
     /// Query for getting one task
     /// </summary>
-    public class GetOneTaskQuery : IRequest<SHTask>
+    public class GetOneTaskQuery : CommonInRepositoryRequest<SHTask>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Id of the task
         /// </summary>

--- a/ScrumHubBackend/CQRS/Tasks/GetOneTaskQuery.cs
+++ b/ScrumHubBackend/CQRS/Tasks/GetOneTaskQuery.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.Tasks
 {

--- a/ScrumHubBackend/CQRS/Tasks/GetTasksForPBIQuery.cs
+++ b/ScrumHubBackend/CQRS/Tasks/GetTasksForPBIQuery.cs
@@ -7,23 +7,8 @@ namespace ScrumHubBackend.CQRS.Tasks
     /// <summary>
     /// Query for getting tasks for one PBI
     /// </summary>
-    public class GetTasksForPBIQuery : IRequest<PaginatedList<SHTask>>
+    public class GetTasksForPBIQuery : CommonInRepositoryRequest<PaginatedList<SHTask>>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Id of the PBI, 0 for unassigned
         /// </summary>

--- a/ScrumHubBackend/CQRS/Tasks/GetTasksForPBIQuery.cs
+++ b/ScrumHubBackend/CQRS/Tasks/GetTasksForPBIQuery.cs
@@ -1,5 +1,4 @@
 ﻿using ScrumHubBackend.CommunicationModel;
-using ScrumHubBackend.CommunicationModel.Common;
 
 namespace ScrumHubBackend.CQRS.Tasks
 {

--- a/ScrumHubBackend/CQRS/Tasks/GetTasksForPBIQuery.cs
+++ b/ScrumHubBackend/CQRS/Tasks/GetTasksForPBIQuery.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
+﻿using ScrumHubBackend.CommunicationModel;
 using ScrumHubBackend.CommunicationModel.Common;
 
 namespace ScrumHubBackend.CQRS.Tasks
@@ -7,7 +6,7 @@ namespace ScrumHubBackend.CQRS.Tasks
     /// <summary>
     /// Query for getting tasks for one PBI
     /// </summary>
-    public class GetTasksForPBIQuery : CommonInRepositoryRequest<PaginatedList<SHTask>>
+    public class GetTasksForPBIQuery : CommonInRepositoryGetListQuery<SHTask>
     {
         /// <summary>
         /// Id of the PBI, 0 for unassigned

--- a/ScrumHubBackend/CQRS/Tasks/GetTasksQuery.cs
+++ b/ScrumHubBackend/CQRS/Tasks/GetTasksQuery.cs
@@ -1,22 +1,11 @@
-﻿using MediatR;
-using ScrumHubBackend.CommunicationModel;
-using ScrumHubBackend.CommunicationModel.Common;
+﻿using ScrumHubBackend.CommunicationModel;
 
 namespace ScrumHubBackend.CQRS.Tasks
 {
     /// <summary>
     /// Get all the tasks from repository
     /// </summary>
-    public class GetTasksQuery : CommonInRepositoryRequest<PaginatedList<SHTask>>
+    public class GetTasksQuery : CommonInRepositoryGetListQuery<SHTask>
     {
-        /// <summary>
-        /// Page number
-        /// </summary>
-        public int PageNumber { get; set; }
-
-        /// <summary>
-        /// Page size
-        /// </summary>
-        public int PageSize { get; set; }
     }
 }

--- a/ScrumHubBackend/CQRS/Tasks/GetTasksQuery.cs
+++ b/ScrumHubBackend/CQRS/Tasks/GetTasksQuery.cs
@@ -7,23 +7,8 @@ namespace ScrumHubBackend.CQRS.Tasks
     /// <summary>
     /// Get all the tasks from repository
     /// </summary>
-    public class GetTasksQuery : IRequest<PaginatedList<SHTask>>
+    public class GetTasksQuery : CommonInRepositoryRequest<PaginatedList<SHTask>>
     {
-        /// <summary>
-        /// Github authorization token
-        /// </summary>
-        public string? AuthToken { get; set; }
-
-        /// <summary>
-        /// Owner of the repository
-        /// </summary>
-        public string? RepositoryOwner { get; set; }
-
-        /// <summary>
-        /// Name of the repository
-        /// </summary>
-        public string? RepositoryName { get; set; }
-
         /// <summary>
         /// Page number
         /// </summary>

--- a/ScrumHubBackend/CommunicationModel/Sprint.cs
+++ b/ScrumHubBackend/CommunicationModel/Sprint.cs
@@ -1,4 +1,7 @@
-﻿namespace ScrumHubBackend.CommunicationModel
+﻿using MediatR;
+using ScrumHubBackend.CQRS;
+
+namespace ScrumHubBackend.CommunicationModel
 {
     /// <summary>
     /// Represents a sprint
@@ -43,14 +46,14 @@
         /// <summary>
         /// Constructor
         /// </summary>
-        public Sprint(DatabaseModel.Sprint dbSprint, DatabaseContext dbContext)
+        public Sprint(DatabaseModel.Sprint dbSprint, ICommonInRepositoryRequest originalRequest, DatabaseContext dbContext, IMediator mediator)
         {
             SprintNumber = dbSprint.SprintNumber;
             Goal = dbSprint.Goal;
             FinishDate = dbSprint.FinishDate.ToString("yyyy-MM-dd 'UTC'");
             Title = dbSprint.Title;
             var relatedDbBacklogItem = dbContext.BacklogItems?.Where(pbi => pbi.SprintId == dbSprint.SprintNumber && pbi.RepositoryId == dbSprint.RepositoryId).ToList();
-            BacklogItems = relatedDbBacklogItem?.Select(pbi => new BacklogItem(pbi, dbContext)).ToList() ?? new List<BacklogItem>();
+            BacklogItems = relatedDbBacklogItem?.Select(pbi => new BacklogItem(pbi, originalRequest, dbContext, mediator)).ToList() ?? new List<BacklogItem>();
             IsCurrent = dbContext.Sprints?
                 .Where(
                     sprint => sprint.RepositoryId == dbSprint.RepositoryId &&


### PR DESCRIPTION
Now all PBIs requested from backend (including PBIs that are part of 'Sprint' response!) have list of tasks inside (not ids, tasks - just as requested by the endpoint for getting all tasks for given pbi)