### PR TITLE
Added onePage parameter

### DIFF
--- a/ScrumHubBackend/CQRS/CommonInRepositoryGetListQuery.cs
+++ b/ScrumHubBackend/CQRS/CommonInRepositoryGetListQuery.cs
@@ -16,5 +16,10 @@ namespace ScrumHubBackend.CQRS
         /// Page size
         /// </summary>
         public int PageSize { get; set; }
+
+        /// <summary>
+        /// True to get everything as one page
+        /// </summary>
+        public bool? OnePage { get; set; }
     }
 }

--- a/ScrumHubBackend/CQRS/Sprints/GetSprintsQueryHandler.cs
+++ b/ScrumHubBackend/CQRS/Sprints/GetSprintsQueryHandler.cs
@@ -45,17 +45,22 @@ namespace ScrumHubBackend.CQRS.Sprints
 
             var sprintsForRepository = dbRepository.GetSprintsForRepository(_dbContext);
 
-            var result = FilterAndPaginateSprints(request, sprintsForRepository ?? new List<DatabaseModel.Sprint>(), request.PageNumber, request.PageSize, request.CompletedFilter);
+            var result = FilterAndPaginateSprints(request, sprintsForRepository ?? new List<DatabaseModel.Sprint>(), request.PageNumber, request.PageSize, request.CompletedFilter, request.OnePage);
             return Task.FromResult(result);
         }
 
         /// <summary>
         /// Paginates sprints and transforms them to model repositories
         /// </summary>
-        public virtual PaginatedList<Sprint> FilterAndPaginateSprints(ICommonInRepositoryRequest request, IEnumerable<DatabaseModel.Sprint> sprints, int pageNumber, int pageSize, bool? completedFilter)
+        public virtual PaginatedList<Sprint> FilterAndPaginateSprints(ICommonInRepositoryRequest request, IEnumerable<DatabaseModel.Sprint> sprints, int pageNumber, int pageSize, bool? completedFilter, bool? onePage)
         {
             var filteredSprints = sprints.Where(sprint => completedFilter == null || (sprint.Status != Common.SprintStatus.NotFinished) == completedFilter.Value);
             var sortedSprints = filteredSprints.OrderBy(sprint => sprint.SprintNumber);
+            if (onePage.HasValue && onePage.Value)
+            {
+                pageNumber = 1;
+                pageSize = sortedSprints.Count();
+            }
             int startIndex = pageSize * (pageNumber - 1);
             int endIndex = Math.Min(startIndex + pageSize, sortedSprints.Count());
             var paginatedSprints = sortedSprints.Take(new Range(startIndex, endIndex));

--- a/ScrumHubBackend/CQRS/Tasks/GetTasksQueryHandler.cs
+++ b/ScrumHubBackend/CQRS/Tasks/GetTasksQueryHandler.cs
@@ -56,15 +56,20 @@ namespace ScrumHubBackend.CQRS.Tasks
 
             _gitHubResynchronization.ResynchronizeIssues(repository, issues, _dbContext);
 
-            return Task.FromResult(PaginateTasks(issues ?? new List<Octokit.Issue>(), request.PageNumber, request.PageSize));
+            return Task.FromResult(PaginateTasks(issues ?? new List<Octokit.Issue>(), request.PageNumber, request.PageSize, request.OnePage));
         }
 
         /// <summary>
         /// Paginates sprints and transforms them to model repositories
         /// </summary>
-        public virtual PaginatedList<SHTask> PaginateTasks(IEnumerable<Octokit.Issue> issues, int pageNumber, int pageSize)
+        public virtual PaginatedList<SHTask> PaginateTasks(IEnumerable<Octokit.Issue> issues, int pageNumber, int pageSize, bool? onePage)
         {
             var sortedIssues = issues.OrderByDescending(iss => iss.UpdatedAt);
+            if(onePage.HasValue && onePage.Value)
+            {
+                pageNumber = 1;
+                pageSize = sortedIssues.Count();
+            }
             int startIndex = pageSize * (pageNumber - 1);
             int endIndex = Math.Min(startIndex + pageSize, sortedIssues.Count());
             var paginatedIssues = sortedIssues.Take(new Range(startIndex, endIndex));

--- a/ScrumHubBackend/Controllers/BacklogItemController.cs
+++ b/ScrumHubBackend/Controllers/BacklogItemController.cs
@@ -39,6 +39,7 @@ namespace ScrumHubBackend.Controllers
         /// <param name="finished">Filter for finished PBIs, true or false</param>
         /// <param name="esimated">Filter for esimated PBIs, true or false</param>
         /// <param name="inSprint">Filters for PBIs that are in a sprint, true or false</param>
+        /// <param name="onePage">True if want to fetch everything as one page, false/skipped otherwise</param>
         [HttpGet("{repositoryOwner}/{repositoryName}")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(PaginatedList<BacklogItem>), (int)HttpStatusCode.OK)]
@@ -54,7 +55,8 @@ namespace ScrumHubBackend.Controllers
             [FromQuery] string? nameFilter = null,
             [FromQuery] bool? finished = null,
             [FromQuery] bool? esimated = null,
-            [FromQuery] bool? inSprint = null
+            [FromQuery] bool? inSprint = null,
+            [FromQuery] bool? onePage = null
             )
         {
             var query = new GetPBIsQuery
@@ -68,6 +70,7 @@ namespace ScrumHubBackend.Controllers
                 FinishedFilter = finished,
                 EstimatedFilter = esimated,
                 InSprintFilter = inSprint,
+                OnePage = onePage
             };
 
             var result = await _mediator.Send(query);

--- a/ScrumHubBackend/Controllers/SprintsController.cs
+++ b/ScrumHubBackend/Controllers/SprintsController.cs
@@ -36,6 +36,7 @@ namespace ScrumHubBackend.Controllers
         /// <param name="pageNumber">Page to get, default = 1</param>
         /// <param name="pageSize">Size of page, default = 10</param>
         /// <param name="completed">Filter for only completed or only not completed sprints</param>
+        /// <param name="onePage">True if want to fetch everything as one page, false/skipped otherwise</param>
         [HttpGet("{repositoryOwner}/{repositoryName}")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(PaginatedList<Sprint>), (int)HttpStatusCode.OK)]
@@ -48,7 +49,8 @@ namespace ScrumHubBackend.Controllers
             [FromRoute] string repositoryName,
             [FromQuery] int pageNumber = 1,
             [FromQuery] int pageSize = 10,
-            [FromQuery] bool? completed = null
+            [FromQuery] bool? completed = null,
+            [FromQuery] bool? onePage = null
             )
         {
             var query = new GetSprintsQuery
@@ -58,7 +60,8 @@ namespace ScrumHubBackend.Controllers
                 RepositoryName = repositoryName,
                 PageNumber = pageNumber,
                 PageSize = pageSize,
-                CompletedFilter = completed
+                CompletedFilter = completed,
+                OnePage = onePage
             };
 
             var result = await _mediator.Send(query);

--- a/ScrumHubBackend/Controllers/TasksController.cs
+++ b/ScrumHubBackend/Controllers/TasksController.cs
@@ -35,6 +35,7 @@ namespace ScrumHubBackend.Controllers
         /// <param name="repositoryName">Name of the repository</param>
         /// <param name="pageNumber">Page to get, default = 1</param>
         /// <param name="pageSize">Size of page, default = 10</param>
+        /// <param name="onePage">True if want to fetch everything as one page, false/skipped otherwise</param>
         [HttpGet("{repositoryOwner}/{repositoryName}")]
         [Produces("application/json")]
         [ProducesResponseType(typeof(PaginatedList<SHTask>), (int)HttpStatusCode.OK)]
@@ -46,7 +47,8 @@ namespace ScrumHubBackend.Controllers
             [FromRoute] string repositoryOwner,
             [FromRoute] string repositoryName,
             [FromQuery] int pageNumber = 1,
-            [FromQuery] int pageSize = 10
+            [FromQuery] int pageSize = 10,
+            [FromQuery] bool? onePage = null
             )
         {
             var query = new GetTasksQuery
@@ -56,6 +58,7 @@ namespace ScrumHubBackend.Controllers
                 RepositoryName = repositoryName,
                 PageNumber = pageNumber,
                 PageSize = pageSize,
+                OnePage = onePage
             };
 
             var result = await _mediator.Send(query);

--- a/ScrumHubBackendTests/CQRS/Sprints/GetSprintsQueryHandlerTests.cs
+++ b/ScrumHubBackendTests/CQRS/Sprints/GetSprintsQueryHandlerTests.cs
@@ -58,10 +58,10 @@ namespace ScrumHubBackendTests.CQRS.Sprints
 
             var handler = new GetSprintsQueryHandler(loggerMock.Object, gitHubClientFactoryMock.Object, dbContextMock.Object, mediatorMock.Object);
 
-            var res1 = handler.FilterAndPaginateSprints(query, sprintsData, 1, 3, null);
-            var res2 = handler.FilterAndPaginateSprints(query, sprintsData, 2, 3, null);
-            var res3 = handler.FilterAndPaginateSprints(query, sprintsData, 3, 3, null);
-            var res4 = handler.FilterAndPaginateSprints(query, sprintsData, 4, 3, null);
+            var res1 = handler.FilterAndPaginateSprints(query, sprintsData, 1, 3, null, null);
+            var res2 = handler.FilterAndPaginateSprints(query, sprintsData, 2, 3, null, null);
+            var res3 = handler.FilterAndPaginateSprints(query, sprintsData, 3, 3, null, null);
+            var res4 = handler.FilterAndPaginateSprints(query, sprintsData, 4, 3, null, null);
 
             Assert.Equal(3, res1.RealSize);
             Assert.Equal(3, res2.RealSize);


### PR DESCRIPTION
By setting `onePage=true` in queries for getting all sprints, all pbis or all tasks, you receive everything as one page (ignoring pageNumber and pageSize). Info about actual size in the response is accurate.