### PR TITLE
Fixing performance issues on downloading anything that contains PBIs and/or tasks

### DIFF
--- a/ScrumHubBackend/CQRS/PBI/AddPBICommandHandler.cs
+++ b/ScrumHubBackend/CQRS/PBI/AddPBICommandHandler.cs
@@ -51,7 +51,7 @@ namespace ScrumHubBackend.CQRS.PBI
 
             newPBI.UpdateAcceptanceCriteria(request.AcceptanceCriteria ?? new List<string>(), _dbContext);
 
-            return Task.FromResult(new BacklogItem(newPBI.Id, request, _dbContext, _mediator));
+            return Task.FromResult(new BacklogItem(newPBI.Id, request, _dbContext, _mediator, true));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/PBI/EstimatePBICommandHandler.cs
+++ b/ScrumHubBackend/CQRS/PBI/EstimatePBICommandHandler.cs
@@ -54,7 +54,7 @@ namespace ScrumHubBackend.CQRS.PBI
             _dbContext.Update(pbi);
             _dbContext.SaveChanges();
 
-            return Task.FromResult(new BacklogItem(pbi.Id, request, _dbContext, _mediator));
+            return Task.FromResult(new BacklogItem(pbi.Id, request, _dbContext, _mediator, true));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/PBI/FinishPBICommandHandler.cs
+++ b/ScrumHubBackend/CQRS/PBI/FinishPBICommandHandler.cs
@@ -54,7 +54,7 @@ namespace ScrumHubBackend.CQRS.PBI
             _dbContext.Update(pbi);
             _dbContext.SaveChanges();
 
-            return Task.FromResult(new BacklogItem(pbi.Id, request, _dbContext, _mediator));
+            return Task.FromResult(new BacklogItem(pbi.Id, request, _dbContext, _mediator, true));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/PBI/GetOnePBIQueryHandler.cs
+++ b/ScrumHubBackend/CQRS/PBI/GetOnePBIQueryHandler.cs
@@ -47,7 +47,7 @@ namespace ScrumHubBackend.CQRS.PBI
             if (pbi == null || pbi?.RepositoryId != dbRepository.Id)
                 throw new NotFoundException("Backlog item not found in ScrumHub");
 
-            return Task.FromResult(new BacklogItem(pbi.Id, request, _dbContext, _mediator));
+            return Task.FromResult(new BacklogItem(pbi.Id, request, _dbContext, _mediator, true));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/PBI/UpdatePBICommandHandler.cs
+++ b/ScrumHubBackend/CQRS/PBI/UpdatePBICommandHandler.cs
@@ -58,7 +58,7 @@ namespace ScrumHubBackend.CQRS.PBI
 
             pbi.UpdateAcceptanceCriteria(request.AcceptanceCriteria ?? new List<string>(), _dbContext);
 
-            return Task.FromResult(new CommunicationModel.BacklogItem(pbi.Id, request, _dbContext, _mediator));
+            return Task.FromResult(new CommunicationModel.BacklogItem(pbi.Id, request, _dbContext, _mediator, true));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/Sprints/AddSprintCommandHandler.cs
+++ b/ScrumHubBackend/CQRS/Sprints/AddSprintCommandHandler.cs
@@ -84,7 +84,7 @@ namespace ScrumHubBackend.CQRS.Sprints
 
             _dbContext.SaveChanges();
 
-            return Task.FromResult(new Sprint(dbSprint, request, _dbContext, _mediator, true));
+            return Task.FromResult(new Sprint(dbSprint, gitHubClient, repository, dbRepository, request, _dbContext, _mediator, true));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/Sprints/AddSprintCommandHandler.cs
+++ b/ScrumHubBackend/CQRS/Sprints/AddSprintCommandHandler.cs
@@ -84,7 +84,7 @@ namespace ScrumHubBackend.CQRS.Sprints
 
             _dbContext.SaveChanges();
 
-            return Task.FromResult(new Sprint(dbSprint, request, _dbContext, _mediator));
+            return Task.FromResult(new Sprint(dbSprint, request, _dbContext, _mediator, true));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/Sprints/FinishSprintCommandHandler.cs
+++ b/ScrumHubBackend/CQRS/Sprints/FinishSprintCommandHandler.cs
@@ -58,7 +58,7 @@ namespace ScrumHubBackend.CQRS.Sprints
             _dbContext.Update(dbSprint);
             _dbContext.SaveChanges();
 
-            return Task.FromResult(new Sprint(dbSprint, request, _dbContext, _mediator, true));
+            return Task.FromResult(new Sprint(dbSprint, gitHubClient, repository, dbRepository, request, _dbContext, _mediator, true));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/Sprints/FinishSprintCommandHandler.cs
+++ b/ScrumHubBackend/CQRS/Sprints/FinishSprintCommandHandler.cs
@@ -58,7 +58,7 @@ namespace ScrumHubBackend.CQRS.Sprints
             _dbContext.Update(dbSprint);
             _dbContext.SaveChanges();
 
-            return Task.FromResult(new Sprint(dbSprint, request, _dbContext, _mediator));
+            return Task.FromResult(new Sprint(dbSprint, request, _dbContext, _mediator, true));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/Sprints/GetOneSprintQueryHandler.cs
+++ b/ScrumHubBackend/CQRS/Sprints/GetOneSprintQueryHandler.cs
@@ -48,7 +48,7 @@ namespace ScrumHubBackend.CQRS.Sprints
             if(dbSprint == null)
                 throw new NotFoundException("Sprint not fount in the repository");
 
-            return Task.FromResult(new Sprint(dbSprint, request, _dbContext, _mediator, true));
+            return Task.FromResult(new Sprint(dbSprint, gitHubClient, repository, dbRepository, request, _dbContext, _mediator, true));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/Sprints/GetOneSprintQueryHandler.cs
+++ b/ScrumHubBackend/CQRS/Sprints/GetOneSprintQueryHandler.cs
@@ -48,7 +48,7 @@ namespace ScrumHubBackend.CQRS.Sprints
             if(dbSprint == null)
                 throw new NotFoundException("Sprint not fount in the repository");
 
-            return Task.FromResult(new Sprint(dbSprint, request, _dbContext, _mediator));
+            return Task.FromResult(new Sprint(dbSprint, request, _dbContext, _mediator, true));
         }
     }
 }

--- a/ScrumHubBackend/CQRS/Sprints/UpdateSprintCommandHandler.cs
+++ b/ScrumHubBackend/CQRS/Sprints/UpdateSprintCommandHandler.cs
@@ -84,7 +84,9 @@ namespace ScrumHubBackend.CQRS.Sprints
             _dbContext.Update(dbSprint);
             _dbContext.SaveChanges();
 
-            return Task.FromResult(new Sprint(dbSprint, request, _dbContext, _mediator));
+#pragma warning disable CS8604 // For some reason VS complains that request can be null - but it is checked before
+            return Task.FromResult(new Sprint(dbSprint,  request, _dbContext, _mediator, true));
+#pragma warning restore CS8604
         }
     }
 }

--- a/ScrumHubBackend/CQRS/Sprints/UpdateSprintCommandHandler.cs
+++ b/ScrumHubBackend/CQRS/Sprints/UpdateSprintCommandHandler.cs
@@ -85,7 +85,7 @@ namespace ScrumHubBackend.CQRS.Sprints
             _dbContext.SaveChanges();
 
 #pragma warning disable CS8604 // For some reason VS complains that request can be null - but it is checked before
-            return Task.FromResult(new Sprint(dbSprint,  request, _dbContext, _mediator, true));
+            return Task.FromResult(new Sprint(dbSprint, gitHubClient, repository, dbRepository, request, _dbContext, _mediator, true));
 #pragma warning restore CS8604
         }
     }

--- a/ScrumHubBackend/CQRS/Tasks/FillPBIsWithTasksCommand.cs
+++ b/ScrumHubBackend/CQRS/Tasks/FillPBIsWithTasksCommand.cs
@@ -1,0 +1,32 @@
+﻿using MediatR;
+using Octokit;
+using ScrumHubBackend.CommunicationModel;
+using ScrumHubBackend.CommunicationModel.Common;
+
+namespace ScrumHubBackend.CQRS.Tasks
+{
+    /// <summary>
+    /// Command for filling list of PBIs from given repository with tasks
+    /// <para>I has no seurity checks with assumption that it is called from another already checked handler</para>
+    /// <para>Returns dictionay from PBI id (from passed list) to ienumerable of tasks that should be added to the PBI</para>
+    /// </summary>
+    public class FillPBIsWithTasksCommand : IRequest<Dictionary<long, IEnumerable<SHTask>>>
+    {
+        /// <summary>
+        /// GitHub client
+        /// </summary>
+        public IGitHubClient? GitHubClient { get; set; }
+        /// <summary>
+        /// Repository where pbis are
+        /// </summary>
+        public Octokit.Repository? Repository { get; set; }
+        /// <summary>
+        /// Database repository corresponding to GitHub repository
+        /// </summary>
+        public DatabaseModel.Repository? DbRepository { get; set; }
+        /// <summary>
+        /// PBIs to attach tasks to
+        /// </summary>
+        public IEnumerable<BacklogItem>? BacklogItems { get; set; }
+    }
+}

--- a/ScrumHubBackend/CQRS/Tasks/FillPBIsWithTasksCommandHandler.cs
+++ b/ScrumHubBackend/CQRS/Tasks/FillPBIsWithTasksCommandHandler.cs
@@ -1,0 +1,66 @@
+﻿using MediatR;
+using ScrumHubBackend.CommunicationModel;
+using ScrumHubBackend.CustomExceptions;
+using ScrumHubBackend.GitHubClient;
+
+namespace ScrumHubBackend.CQRS.Tasks
+{
+    /// <summary>
+    /// Handler for filling PBIs with tasks
+    /// </summary>
+    public class FillPBIsWithTasksCommandHandler : IRequestHandler<FillPBIsWithTasksCommand, Dictionary<long, IEnumerable<SHTask>>>
+    {
+        private readonly ILogger<FillPBIsWithTasksCommandHandler> _logger;
+        private readonly IGitHubResynchronization _gitHubResynchronization;
+        private readonly DatabaseContext _dbContext;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public FillPBIsWithTasksCommandHandler(ILogger<FillPBIsWithTasksCommandHandler> logger, IGitHubResynchronization gitHubResynchronization, DatabaseContext dbContext)
+        {
+            _logger = logger ?? throw new ArgumentException(null, nameof(logger));
+            _dbContext = dbContext ?? throw new ArgumentException(null, nameof(dbContext));
+            _gitHubResynchronization = gitHubResynchronization ?? throw new ArgumentException(null, nameof(gitHubResynchronization));
+        }
+
+        /// <inheritdoc/>
+        public Task<Dictionary<long, IEnumerable<SHTask>>> Handle(FillPBIsWithTasksCommand request, CancellationToken cancellationToken)
+        {
+            if (request.BacklogItems == null || request.GitHubClient == null || request.Repository == null || request.DbRepository == null)
+                throw new Exception($"{nameof(FillPBIsWithTasksCommandHandler)} - null elements in the command");
+            if (request.DbRepository.GitHubId != request.Repository.Id)
+                throw new Exception($"{nameof(FillPBIsWithTasksCommandHandler)} - repositories are not matching");
+
+            var repositoryIssueRequest = new Octokit.RepositoryIssueRequest
+            {
+                State = Octokit.ItemStateFilter.All
+            };
+
+            var issuesAndPullRequests = request.GitHubClient.Issue.GetAllForRepository(request.Repository.Id, repositoryIssueRequest).Result;
+            if (issuesAndPullRequests == null)
+                throw new NotFoundException("Issues not found");
+
+            var issues = issuesAndPullRequests.Where(iss => iss.PullRequest == null);
+
+            _gitHubResynchronization.ResynchronizeIssues(request.Repository, issues, request.GitHubClient, _dbContext);
+
+            // Fill Issues huh?
+            var repoTasks = request.DbRepository.GetTasksForRepository(_dbContext);
+
+            Dictionary<long, IEnumerable<SHTask>> pbiToTaskList = new();
+
+            foreach (var pbi in request.BacklogItems)
+            {
+                var filteredTasks = repoTasks.Where(rt => pbi.Id <= 0 ? (rt.PBI == null || rt.PBI <= 0) : (rt.PBI != null && rt.PBI == pbi.Id));
+                var filteredIssues = filteredTasks.Select(rt => issues.FirstOrDefault(iss => iss.Id == rt.GitHubIssueId) ?? null);
+                var notNullIssues = filteredIssues.Where(iss => iss != null).Select(iss => iss!);
+                var transformedTasks = notNullIssues.Select(rt => new SHTask(rt, _dbContext));
+
+                pbiToTaskList[pbi.Id] = transformedTasks;
+            }
+
+            return Task.FromResult(pbiToTaskList);
+        }
+    }
+}

--- a/ScrumHubBackend/CQRS/Tasks/GetTasksForPBIQueryHandler.cs
+++ b/ScrumHubBackend/CQRS/Tasks/GetTasksForPBIQueryHandler.cs
@@ -57,7 +57,7 @@ namespace ScrumHubBackend.CQRS.Tasks
 
             var issues = issuesAndPullRequests.Where(iss => iss.PullRequest == null);
 
-            _gitHubResynchronization.ResynchronizeIssues(repository, gitHubClient, _dbContext);
+            _gitHubResynchronization.ResynchronizeIssues(repository, issues, gitHubClient, _dbContext);
 
             var repoTasks = dbRepository.GetTasksForRepository(_dbContext);
 

--- a/ScrumHubBackend/CQRS/Tasks/GetTasksQueryHandler.cs
+++ b/ScrumHubBackend/CQRS/Tasks/GetTasksQueryHandler.cs
@@ -54,7 +54,7 @@ namespace ScrumHubBackend.CQRS.Tasks
 
             var issues = issuesAndPullRequests.Where(iss => iss.PullRequest == null);
 
-            _gitHubResynchronization.ResynchronizeIssues(repository, gitHubClient, _dbContext);
+            _gitHubResynchronization.ResynchronizeIssues(repository, issues, gitHubClient, _dbContext);
 
             return Task.FromResult(PaginateTasks(issues ?? new List<Octokit.Issue>(), request.PageNumber, request.PageSize, request.OnePage));
         }

--- a/ScrumHubBackend/CommunicationModel/Sprint.cs
+++ b/ScrumHubBackend/CommunicationModel/Sprint.cs
@@ -57,7 +57,7 @@ namespace ScrumHubBackend.CommunicationModel
         /// <summary>
         /// Constructor
         /// </summary>
-        public Sprint(DatabaseModel.Sprint dbSprint, ICommonInRepositoryRequest originalRequest, DatabaseContext dbContext, IMediator mediator)
+        public Sprint(DatabaseModel.Sprint dbSprint, ICommonInRepositoryRequest originalRequest, DatabaseContext dbContext, IMediator mediator, bool fillTasks)
         {
             SprintNumber = dbSprint.SprintNumber;
             Goal = dbSprint.Goal;
@@ -66,7 +66,7 @@ namespace ScrumHubBackend.CommunicationModel
             Status = dbSprint.Status;
 
             var relatedDbBacklogItem = dbContext.BacklogItems?.Where(pbi => pbi.SprintId == dbSprint.SprintNumber && pbi.RepositoryId == dbSprint.RepositoryId).ToList();
-            BacklogItems = relatedDbBacklogItem?.Select(pbi => new BacklogItem(pbi, originalRequest, dbContext, mediator)).ToList() ?? new List<BacklogItem>();
+            BacklogItems = relatedDbBacklogItem?.Select(pbi => new BacklogItem(pbi, originalRequest, dbContext, mediator, fillTasks)).ToList() ?? new List<BacklogItem>();
             IsCurrent = dbContext.Sprints?
                 .Where(
                     sprint => sprint.RepositoryId == dbSprint.RepositoryId &&

--- a/ScrumHubBackend/CommunicationModel/Sprint.cs
+++ b/ScrumHubBackend/CommunicationModel/Sprint.cs
@@ -1,6 +1,8 @@
 ﻿using MediatR;
+using Octokit;
 using ScrumHubBackend.Common;
 using ScrumHubBackend.CQRS;
+using ScrumHubBackend.CQRS.Tasks;
 
 namespace ScrumHubBackend.CommunicationModel
 {
@@ -57,7 +59,7 @@ namespace ScrumHubBackend.CommunicationModel
         /// <summary>
         /// Constructor
         /// </summary>
-        public Sprint(DatabaseModel.Sprint dbSprint, ICommonInRepositoryRequest originalRequest, DatabaseContext dbContext, IMediator mediator, bool fillTasks)
+        public Sprint(DatabaseModel.Sprint dbSprint, IGitHubClient gitHubClient, Octokit.Repository repository, DatabaseModel.Repository dbRepository, ICommonInRepositoryRequest originalRequest, DatabaseContext dbContext, IMediator mediator, bool fillTasks)
         {
             SprintNumber = dbSprint.SprintNumber;
             Goal = dbSprint.Goal;
@@ -66,7 +68,26 @@ namespace ScrumHubBackend.CommunicationModel
             Status = dbSprint.Status;
 
             var relatedDbBacklogItem = dbContext.BacklogItems?.Where(pbi => pbi.SprintId == dbSprint.SprintNumber && pbi.RepositoryId == dbSprint.RepositoryId).ToList();
-            BacklogItems = relatedDbBacklogItem?.Select(pbi => new BacklogItem(pbi, originalRequest, dbContext, mediator, fillTasks)).ToList() ?? new List<BacklogItem>();
+            BacklogItems = relatedDbBacklogItem?.Select(pbi => new BacklogItem(pbi, originalRequest, dbContext, mediator, false)).ToList() ?? new List<BacklogItem>();
+
+            if(fillTasks)
+            {
+                var fillTasksCommand = new FillPBIsWithTasksCommand()
+                {
+                    GitHubClient = gitHubClient,
+                    Repository = repository,
+                    DbRepository = dbRepository,
+                    BacklogItems = BacklogItems
+                };
+
+                var pbiTasks = mediator.Send(fillTasksCommand).Result;
+
+                foreach (var pbi in BacklogItems)
+                {
+                    pbi.AddTasks(pbiTasks[pbi.Id]);
+                }
+            }
+
             IsCurrent = dbContext.Sprints?
                 .Where(
                     sprint => sprint.RepositoryId == dbSprint.RepositoryId &&

--- a/ScrumHubBackend/GitHubClient/GitHubResynchronization.cs
+++ b/ScrumHubBackend/GitHubClient/GitHubResynchronization.cs
@@ -14,7 +14,7 @@ namespace ScrumHubBackend.GitHubClient
         /// Resynchronizes issued between GitHub and ScrumHub
         /// </summary>
         /// <exception cref="CustomExceptions.NotFoundException">Repository not found</exception>
-        void ResynchronizeIssues(Octokit.Repository repo, IGitHubClient gitHubClient, DatabaseContext dbContext);
+        void ResynchronizeIssues(Octokit.Repository repo, IEnumerable<Issue> repositoryIssues, IGitHubClient gitHubClient, DatabaseContext dbContext);
     }
 
     /// <summary>
@@ -23,20 +23,13 @@ namespace ScrumHubBackend.GitHubClient
     public class GitHubResynchronization : IGitHubResynchronization
     {
         /// <inheritdoc/>
-        public void ResynchronizeIssues(Octokit.Repository repository, IGitHubClient gitHubClient, DatabaseContext dbContext)
+        public void ResynchronizeIssues(Octokit.Repository repository, IEnumerable<Issue> repositoryIssues, IGitHubClient gitHubClient, DatabaseContext dbContext)
         {
-            var repositoryIssueRequest = new RepositoryIssueRequest
-            {
-                State = ItemStateFilter.All,
-            };
-
             var repositoryPRsRequest = new PullRequestRequest
             {
                 State = ItemStateFilter.All
             };
 
-            var issuesAndPullRequests = gitHubClient.Issue.GetAllForRepository(repository.Id, repositoryIssueRequest).Result;
-            var repositoryIssues = issuesAndPullRequests.Where(iapr => iapr.PullRequest == null);
             var repositoryPRsToDefaultBranch = 
                 gitHubClient.PullRequest.GetAllForRepository(repository.Id, repositoryPRsRequest)
                     .Result.Where( pr => 

--- a/ScrumHubBackendTests/CQRS/Sprints/GetSprintsQueryHandlerTests.cs
+++ b/ScrumHubBackendTests/CQRS/Sprints/GetSprintsQueryHandlerTests.cs
@@ -51,6 +51,14 @@ namespace ScrumHubBackendTests.CQRS.Sprints
                     )
                 );
 
+            mediatorMock.Setup(
+                m => m.Send(It.IsAny<FillPBIsWithTasksCommand>(), It.IsAny<CancellationToken>())
+                ).Returns(
+                    Task.FromResult(
+                        new Dictionary<long, IEnumerable<ScrumHubBackend.CommunicationModel.SHTask>>()
+                    )
+                );
+
             var query = new GetSprintsQuery()
             {
 
@@ -58,10 +66,12 @@ namespace ScrumHubBackendTests.CQRS.Sprints
 
             var handler = new GetSprintsQueryHandler(loggerMock.Object, gitHubClientFactoryMock.Object, dbContextMock.Object, mediatorMock.Object);
 
-            var res1 = handler.FilterAndPaginateSprints(query, sprintsData, 1, 3, null, null);
-            var res2 = handler.FilterAndPaginateSprints(query, sprintsData, 2, 3, null, null);
-            var res3 = handler.FilterAndPaginateSprints(query, sprintsData, 3, 3, null, null);
-            var res4 = handler.FilterAndPaginateSprints(query, sprintsData, 4, 3, null, null);
+#pragma warning disable CS8625 // Skipping warning on nulls passed to variables not marked with ? since their ussage is mocked
+            var res1 = handler.FilterAndPaginateSprints(query, sprintsData, 1, 3, null, null, null, null, null);
+            var res2 = handler.FilterAndPaginateSprints(query, sprintsData, 2, 3, null, null, null, null, null);
+            var res3 = handler.FilterAndPaginateSprints(query, sprintsData, 3, 3, null, null, null, null, null);
+            var res4 = handler.FilterAndPaginateSprints(query, sprintsData, 4, 3, null, null, null, null, null);
+#pragma warning restore CS8625
 
             Assert.Equal(3, res1.RealSize);
             Assert.Equal(3, res2.RealSize);
@@ -78,6 +88,7 @@ namespace ScrumHubBackendTests.CQRS.Sprints
             Assert.Equal(6, res2.List.ElementAt(2).SprintNumber);
 
             Assert.Empty(res4.List);
+            
         }
     }
 }


### PR DESCRIPTION
When downloading pbis/sprints instead of time scaling linearly with number of pbis to download (~2-4s per pbi) it is constant (~1.5-2.5s depending on what we want to download). It concerns not only downloading lists but also updates and single sprints.

Additionally task synchronisation is faster (it is a part of changes above, but also task related requests are about 0.5s faster).
